### PR TITLE
Création des tables de Framadate si elles n'existent pas lors du démarage de l'image

### DIFF
--- a/framadate/Dockerfile
+++ b/framadate/Dockerfile
@@ -8,7 +8,7 @@ ENV SHELL /bin/bash
 RUN apt-get update;apt-get -y upgrade
 
 # Install apache, PHP, and supplimentary programs. curl and lynx-cur are for debugging the container.
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install apache2 libapache2-mod-php5 php5-mysql php5-gd php-pear php-apc php5-curl curl php5-adodb php-gettext git
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install apache2 libapache2-mod-php5 php5-mysql php5-gd php-pear php-apc php5-curl curl php5-adodb php-gettext git mysql-client
 
 # Enable apache mods.
 RUN a2enmod php5;a2enmod rewrite

--- a/framadate/scripts/run.sh
+++ b/framadate/scripts/run.sh
@@ -18,7 +18,7 @@ sed -i -e"s/<relative path to the logo file for pdf>/ /" /var/www/app/inc/consta
 php -r "readfile('https://getcomposer.org/installer');" | php
 ./composer.phar install --no-interaction
 
-# Acces à la BDD pour créer les tables nécessaires a Framadate ()si elles n'existent pas déjà)
+# Db access in order to create required Framadate tables ( if not exist)
 mysql -u $MYSQL_USER -p$MYSQL_PASSWORD -h $MYSQL_PORT_3306_TCP_ADDR $MYSQL_NAME < /var/www/install/install.mysql.sql
 
 exec /usr/sbin/apache2ctl -D FOREGROUND

--- a/framadate/scripts/run.sh
+++ b/framadate/scripts/run.sh
@@ -18,4 +18,7 @@ sed -i -e"s/<relative path to the logo file for pdf>/ /" /var/www/app/inc/consta
 php -r "readfile('https://getcomposer.org/installer');" | php
 ./composer.phar install --no-interaction
 
+# Acces à la BDD pour créer les tables nécessaires a Framadate ()si elles n'existent pas déjà)
+mysql -u $MYSQL_USER -p$MYSQL_PASSWORD -h $MYSQL_PORT_3306_TCP_ADDR $MYSQL_NAME < /var/www/install/install.mysql.sql
+
 exec /usr/sbin/apache2ctl -D FOREGROUND


### PR DESCRIPTION
Ajout de mysql-client lors de l'instalation afin de pouvoir executer le
script /var/www/install/install.mysql.sql qui créée les tables si elles n'existent pas.
